### PR TITLE
enable full association restrictions for Pixel Health app

### DIFF
--- a/sysconfig/fir-proximity-feature.xml
+++ b/sysconfig/fir-proximity-feature.xml
@@ -4,4 +4,7 @@
 
 <config>
     <feature name="com.google.android.feature.FIR.PROXIMITY" />
+<!-- On stock OS, association is allowed to Private Compute Services which are unused on GrapheneOS.-->
+<!-- Empty "allowed" value enables full association restrictions.-->
+    <allow-association target="com.google.android.pixel.health" allowed="" />
 </config>


### PR DESCRIPTION
Pixel Health app is already restricted to interacting only with preinstalled apps, this change restricts it further to match and exceed all aspects of restrictions that Pixel Health app has on stock OS.