### PR TITLE
bt: update vendor.google.bluetooth_ext to version 1-3

### DIFF
--- a/bcmbt/compatibility_matrix.xml
+++ b/bcmbt/compatibility_matrix.xml
@@ -1,7 +1,7 @@
 <compatibility-matrix version="1.0" type="framework">
     <hal format="aidl" optional="true">
         <name>vendor.google.bluetooth_ext</name>
-        <version>2</version>
+        <version>1-3</version>
         <interface>
             <name>IBluetoothFinder</name>
             <instance>default</instance>


### PR DESCRIPTION
Stock BP2A images indicate this version